### PR TITLE
Adding two new Windows Sensors

### DIFF
--- a/Windows-Samples/Sensors/os_memory_virtual_setting.ps1
+++ b/Windows-Samples/Sensors/os_memory_virtual_setting.ps1
@@ -1,0 +1,10 @@
+# Returns the current paging file
+# Execution Context: User
+
+$virtualsize = Get-WmiObject Win32_PageFileSetting | where name -EQ "C:\pagefile.sys" | select MaximumSize
+if ($virtualsize -ne $null) {
+Write-Output $virtualsize
+ } 
+ else {
+  Write-Output ""
+  }

--- a/Windows-Samples/Sensors/os_printers.ps1
+++ b/Windows-Samples/Sensors/os_printers.ps1
@@ -1,0 +1,8 @@
+# Returns the current list of network printers
+# Execution Context: User
+$Printers = (Get-Printer | where type -eq "Connection").Name -join ','
+if ($Printers -ne $null) {
+ Write-Output $Printers
+ } else {
+  Write-Output ""
+}


### PR DESCRIPTION
I created a few useful windows sensors that I want to add:

1. Pulls a list of printers and then joins them to a single line to write to WS1 Intelligence
2. Pulls the current virtual memory paging file setting