### PR TITLE
Fix 'Example' code block in Bulk Device Commands README

### DIFF
--- a/Windows-Samples/Tools & Utilities/Bulk Device Commands/README.md
+++ b/Windows-Samples/Tools & Utilities/Bulk Device Commands/README.md
@@ -22,7 +22,8 @@ When run, the script will retrieve a list of devices from the provided Smart Gro
 1. You will need to supply your AirWatch Admin credentials, including the AirWatch API Key.
 
 ## EXAMPLE
-  .\Bulk-DeviceCommand.ps1 `
+```
+.\Bulk-DeviceCommand.ps1 `
     -awServer "https://YourTenant.com" `
     -awTenantAPIKey "YourAPIKey" `
     -awAPIUsername "YourUserName" `
@@ -30,7 +31,7 @@ When run, the script will retrieve a list of devices from the provided Smart Gro
     -smartGroup "Beta Testers" `
     -command "Lock" `
     -Verbose
-
+```
 ## Parameters
 
 **awServer**

--- a/Windows-Samples/Tools & Utilities/Bulk Device Commands/README.md
+++ b/Windows-Samples/Tools & Utilities/Bulk Device Commands/README.md
@@ -23,14 +23,14 @@ When run, the script will retrieve a list of devices from the provided Smart Gro
 
 ## EXAMPLE
 
-    .\Change-EnrollmentUser.ps1 `
-        -awServer "https://YourTenant.com" `
-        -awTenantAPIKey "YourAPIKey" `
-        -awAPIUsername "YourUserName" `
-        -awAPIPassword "YourPassword" `
-        -smartGroup "Beta Users" `
-        -command "Lock" `
-        -Verbose
+  .\Bulk-DeviceCommand.ps1 `
+    -awServer "https://YourTenant.com" `
+    -awTenantAPIKey "YourAPIKey" `
+    -awAPIUsername "YourUserName" `
+    -awAPIPassword "YourPassword" `
+    -smartGroup "Beta Testers" `
+    -command "Lock" `
+    -Verbose
 
 ## Parameters
 

--- a/Windows-Samples/Tools & Utilities/Bulk Device Commands/README.md
+++ b/Windows-Samples/Tools & Utilities/Bulk Device Commands/README.md
@@ -22,7 +22,6 @@ When run, the script will retrieve a list of devices from the provided Smart Gro
 1. You will need to supply your AirWatch Admin credentials, including the AirWatch API Key.
 
 ## EXAMPLE
-
   .\Bulk-DeviceCommand.ps1 `
     -awServer "https://YourTenant.com" `
     -awTenantAPIKey "YourAPIKey" `


### PR DESCRIPTION
Looks like there was a bad copypasta on the Windows 'Bulk Device Commands' `README.md`.