### PR TITLE
Update Readme.md

### DIFF
--- a/macOS-Samples/3rd-Party_Software_Guidance/Mozilla Firefox/README.md
+++ b/macOS-Samples/3rd-Party_Software_Guidance/Mozilla Firefox/README.md
@@ -403,6 +403,8 @@ The contents of the XML should look similar to this (modify or remove items as n
 		<true/>
 		<key>security.default_personal_cert</key>
 		<string>Ask Every Time</string>
+		<key>security.osclientcerts.autoload</key>
+	        <true/>
 	</dict>
 	<key>Proxy</key>
 	<dict>


### PR DESCRIPTION
Adding security.osclientcerts.autoload key to Preferences dictionary -- support firefox import of certs in user's keychain (identities for SSO)