### PR TITLE
Update com.vmware.migrator.plist

### DIFF
--- a/macOS-Samples/Tools/Migration-Tool/payload/Library/LaunchDaemons/com.vmware.migrator.plist
+++ b/macOS-Samples/Tools/Migration-Tool/payload/Library/LaunchDaemons/com.vmware.migrator.plist
@@ -11,7 +11,7 @@
 		<string>--custom</string>
 		<string>--removal-script</string>
 		<string>/Library/Application Support/VMware/MigratorResources/removemgmt.sh</string>
-		<string>--auto-reboot-delay</string>
+		<string>--forced-restart-delay/string>
 		<string>30</string>
 	</array>
 	<key>RunAtLoad</key>


### PR DESCRIPTION
The flag for --auto-reboot-delay no longer works. We need to use --forced-restart-delay