### PR TITLE
Initial release of sync script for all platforms

### DIFF
--- a/API-Samples/Workspace ONE UEM Samples/Sync Devices/README.md
+++ b/API-Samples/Workspace ONE UEM Samples/Sync Devices/README.md
@@ -1,0 +1,53 @@
+# Workspace ONE UEM Device Sync
+
+## SYNOPSIS
+This script is useful for initiating a sync from the client application to the Workspace ONE UEM application server (Device Services). There are two ways in which the script can be executed; ad-hoc with a menu, and on a recurring schedule without a menu.
+
+## DESCRIPTION
+Within the 'WithMenu' folder, the SyncDevices-Menu.ps1 file can be use on an ad-hoc basis. This script will require manually entering the API Key, Workspace ONE UEM API Endpoint URL, and credentials to authenticate against the API. The script can be executed by double clicking the file within a Windows GUI, or from command line interace.
+
+Within the 'TaskScheduler' folder, the SyncDevices-TaskScheduler.ps1 file can be used within Windows Task Scheduler and executed on a recurring basis. This script will require a one-time setup within the config.ini file. The config.ini file will require the manual entry of the API Key, Workspace ONE UEM API Endpoint URL, and base64 encoded credentials to authenticate against the API. The script can be executed by double clicking SyncDevices-TaskScheduler.ps1 file within a Windows GUI, or by command line interace, or by scheduling a recurring task in Windows Task Scheduler. If the account used to run the script is locked out, or the password has rotated; the base64 encoded credential will require update in the config.ini file. To retrieve the base64 encoded credential; an optional script is included, base64.ps1.
+
+---
+
+## GETTING STARTED
+
+For use with SyncDevices-Menu.ps1
+
+1. Copy the script to destination
+2. Double click the file SyncDevices-Menu.ps1
+3. Provide the Workspace ONE UEM URL in the following format:
+https://server.domain.com
+4. Provide the API Key
+5. Provide the credentials
+
+
+For use with SyncDevices-TaskScheduler.ps1
+
+1. Copy the script to destination
+2. Open config.ini
+3. Paste in API Key, base64 encoded credentials, and Workspace ONE UEM URL. The Workspace ONE UEM URL should be in the following format:
+https://server.domain.com
+4. Open Windows Task Scheduler
+5. Click 'Create Task'
+6. Provide a name for the task, specify 'Run whether user is logged on or not'
+7. Click 'Actions', followed by 'New'
+8. Specify the SyncDevices-TaskScheduler.ps1 in 'Program/script' and click 'OK'
+9. Click 'Triggers', followed by 'New'
+10. Specify the frequency required and ensure 'Enabled' is checked
+11. Click 'OK', followed by 'OK'
+
+---
+
+## OUTPUTS
+There are no outputs
+
+---
+
+## NOTES
+
+* Version:        1.0
+* Creation Date:  09/03/2021
+* Author:         Ryan Pringnitz - rpringnitz@vmware.com
+* Author:         Made with love in Kalamazoo, Michigan
+* Purpose/Change: Initial Release

--- a/API-Samples/Workspace ONE UEM Samples/Sync Devices/TaskScheduler/SyncDevices-TaskScheduler.ps1
+++ b/API-Samples/Workspace ONE UEM Samples/Sync Devices/TaskScheduler/SyncDevices-TaskScheduler.ps1
@@ -1,0 +1,109 @@
+<#
+.SYNOPSIS
+Script to sync devices in Workspace ONE UEM
+
+.NOTES
+Version:        1.0
+Creation Date:  09/03/2021
+Author:         Ryan Pringnitz - rpringnitz@vmware.com
+Author:         Made with love in Kalamazoo, Michigan
+Purpose/Change: Initial Release
+
+#>
+
+#----------------------------------------------------------[Declarations]----------------------------------------------------------
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+#-----------------------------------------------------------[Functions]------------------------------------------------------------
+Function Get-Environment {
+    $script:config = "$PSScriptRoot\config.ini"
+    Write-Host Getting config from $config
+    $WS1Env = Get-Content -Path "$config" | Select -Skip 1 | ConvertFrom-StringData
+    $script:WSOServer = $WS1Env.Environment
+    $script:apiKey = $WS1Env.apikey
+    $script:b64 = $WS1Env.b64
+    $encodedString = "Basic " + $b64
+    $script:header = @{
+        "Authorization" = $encodedString; 
+        "aw-tenant-code" = $apiKey; 
+        "Accept" = "application/json"; 
+        "Content-Type" = "application/json"
+    }
+    return $script:header,$script:WSOServer
+}
+Function Get-Devices {
+    Param(
+    [Parameter(Mandatory=$true)]
+    [string]$WSOServer,
+    [HashTable]$header  
+    )
+    
+    try {
+        $pagesize = 500
+        $script:devices = @()
+        $pageloop = 0
+        $ServicePoint = [System.Net.ServicePointManager]::FindServicePoint($WSOServer)
+        $script:devices += Invoke-RestMethod -Uri "$WSOServer/API/mdm/devices/search?page=0&pagesize=$pagesize" -Headers $header 
+        $ServicePoint.CloseConnectionGroup("")
+        $assignedPages = $devices[$pageloop].Total / $pagesize
+        $assignedPages = "{0:f0}" -f $assignedPages
+        $pageloop++
+        $apiCounter++
+        for (;$pageloop -le $assignedPages;) {
+            $ServicePoint = [System.Net.ServicePointManager]::FindServicePoint($WSOServer)
+            $script:devices += Invoke-RestMethod -Uri "$WSOServer/API/mdm/devices/search?page=$pageloop&pagesize=$pagesize" -Headers $header 
+            $ServicePoint.CloseConnectionGroup("")
+            $pageloop++
+        }
+        Write-host $script:devices.Devices.Count "devices found"        
+        return $script:devices
+    } catch {
+        Write-Host "An error occurred when logging on $_"
+        break
+    }  
+}    
+Function Get-EnrolledDevice {
+    Param(
+    [Parameter(Mandatory=$true)]
+    [System.Object]$Devices    
+    )
+    $script:enrolledDevices = $Devices.Devices | Where-Object { $_.EnrollmentStatus -eq 'Enrolled'}
+    return $script:enrolledDevices
+}
+Function Get-DeviceId {
+    Param(
+    [Parameter(Mandatory=$true)]
+    [System.Object]$EnrolledDevices    
+    )
+    $script:id = $enrolledDevices.Id.Value
+    return $script:id
+}
+Function Invoke-DeviceSync {
+    Param(
+    [Parameter(Mandatory=$true)]
+    [System.Object]$DeviceId,
+    [string]$WSOServer,
+    [HashTable]$header
+    )
+        
+        try {
+            foreach ($devID in $id){ 
+                $ServicePoint = [System.Net.ServicePointManager]::FindServicePoint($WSOServer)
+                Invoke-WebRequest -Uri "$WSOServer/API/mdm/devices/$devID/commands?command=SyncDevice" -Headers $header -Method 'POST'
+                $ServicePoint.CloseConnectionGroup("")
+            }
+        } catch {
+            Write-Host "An error occurred when logging on $_"
+            break
+        }
+    }
+    function Invoke-AutoDeviceSync {
+        Get-Environment 
+        Get-Devices -WSOServer $WSOServer -header $header
+        Get-EnrolledDevice -Devices $devices
+        Get-DeviceId -EnrolledDevices $enrolledDevices
+        Invoke-DeviceSync -DeviceId $id -WSOServer $WSOServer -header $header
+    }
+
+
+    Invoke-AutoDeviceSync
+    

--- a/API-Samples/Workspace ONE UEM Samples/Sync Devices/TaskScheduler/base64.ps1
+++ b/API-Samples/Workspace ONE UEM Samples/Sync Devices/TaskScheduler/base64.ps1
@@ -1,0 +1,22 @@
+Function Get-Base64Encode {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$UserPass 
+        )
+    $Bytes = [System.Text.Encoding]::UTF8.GetBytes($UserPass)
+    $script:cred =[Convert]::ToBase64String($Bytes)
+    return $script:cred   
+}
+
+if ([string]::IsNullOrEmpty($Username))
+{
+    $Username = Read-Host -Prompt 'Enter the account to access Workspace ONE UEM API'       
+}
+if ([string]::IsNullOrEmpty($Password))
+{
+    $Password = Read-Host -Prompt 'Enter the password to access Workspace ONE UEM API'    
+}
+
+$combined = $Username + ":" + $Password
+Get-Base64Encode -UserPass $combined
+Write-Host Paste the value on the third line of config.ini. Value: $cred

--- a/API-Samples/Workspace ONE UEM Samples/Sync Devices/TaskScheduler/config.ini
+++ b/API-Samples/Workspace ONE UEM Samples/Sync Devices/TaskScheduler/config.ini
@@ -1,0 +1,4 @@
+#environment info
+apikey=a/P3xypE08ltuYjgecv2SAMPLEDATAkdsah878=
+b64=YWRtaW5pxsjahsjkahsSAMPLEDATA=
+Environment=https://ws1.acme.com

--- a/API-Samples/Workspace ONE UEM Samples/Sync Devices/WithMenu/SyncDevices-Menu.ps1
+++ b/API-Samples/Workspace ONE UEM Samples/Sync Devices/WithMenu/SyncDevices-Menu.ps1
@@ -1,0 +1,144 @@
+<#
+.SYNOPSIS
+Script to sync devices in Workspace ONE UEM
+
+.NOTES
+Version:        1.0
+Creation Date:  09/03/2021
+Author:         Ryan Pringnitz - rpringnitz@vmware.com
+Author:         Made with love in Kalamazoo, Michigan
+Purpose/Change: Initial Release
+
+#>
+
+#----------------------------------------------------------[Declarations]----------------------------------------------------------
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+#-----------------------------------------------------------[Functions]------------------------------------------------------------
+Function Get-Environment {
+    
+    if ([string]::IsNullOrEmpty($script:WSOServer))
+    {
+        $script:WSOServer = Read-Host -Prompt 'Enter the Workspace ONE UEM Server Name'       
+    }
+    if ([string]::IsNullOrEmpty($script:apiKey))
+    {
+        $script:apiKey = Read-Host -Prompt 'Enter the Workspace ONE UEM API Key'       
+    }
+    if ([string]::IsNullOrEmpty($script:cred))
+    {
+        $script:cred = Get-Credential -Message 'Enter credentials to access the Workspace ONE UEM API'
+    }
+    
+    $script:header = @{
+        "aw-tenant-code" = $apiKey;
+        "Accept"		 = "application/json";
+        "Content-Type"   = "application/json";
+    }
+    
+    return $script:header,$script:WSOServer,$script:apiKey,$script:cred
+}
+Function Get-Devices {
+    Param(
+    [Parameter(Mandatory=$true)]
+    [string]$WSOServer,
+    [HashTable]$header,
+    [PSCredential]$Credential   
+    )
+    
+    try {
+        $pagesize = 500
+        $script:devices = @()
+        $pageloop = 0
+        $ServicePoint = [System.Net.ServicePointManager]::FindServicePoint($WSOServer)
+        $script:devices += Invoke-RestMethod -Uri "$WSOServer/API/mdm/devices/search?page=0&pagesize=$pagesize" -Headers $header -Credential $cred
+        $ServicePoint.CloseConnectionGroup("")
+        $assignedPages = $devices[$pageloop].Total / $pagesize
+        $assignedPages = "{0:f0}" -f $assignedPages
+        $pageloop++
+        $apiCounter++
+        for (;$pageloop -le $assignedPages;) {
+            $ServicePoint = [System.Net.ServicePointManager]::FindServicePoint($WSOServer)
+            $script:devices += Invoke-RestMethod -Uri "$WSOServer/API/mdm/devices/search?page=$pageloop&pagesize=$pagesize" -Headers $header -Credential $cred
+            $ServicePoint.CloseConnectionGroup("")
+            $pageloop++
+        }
+        Write-host $script:devices.Devices.Count "devices found"        
+        return $script:devices
+    } catch {
+        Write-Host "An error occurred when logging on $_"
+        break
+    }  
+}    
+Function Get-EnrolledDevice {
+    Param(
+    [Parameter(Mandatory=$true)]
+    [System.Object]$Devices    
+    )
+    $script:enrolledDevices = $Devices.Devices | Where-Object { $_.EnrollmentStatus -eq 'Enrolled'}
+    return $script:enrolledDevices
+}
+Function Get-DeviceId {
+    Param(
+    [Parameter(Mandatory=$true)]
+    [System.Object]$EnrolledDevices    
+    )
+    $script:id = $enrolledDevices.Id.Value
+    return $script:id
+}
+Function Invoke-DeviceSync {
+    Param(
+    [Parameter(Mandatory=$true)]
+    [System.Object]$DeviceId,
+    [string]$WSOServer,
+    [HashTable]$header,
+    [PSCredential]$Credential   
+    )
+        
+        try {
+            foreach ($devID in $id){ 
+                $ServicePoint = [System.Net.ServicePointManager]::FindServicePoint($WSOServer)
+                Invoke-WebRequest -Uri "$WSOServer/API/mdm/devices/$devID/commands?command=SyncDevice" -Headers $header -Method 'POST' -Credential $cred
+                $ServicePoint.CloseConnectionGroup("")
+            }
+        } catch {
+            Write-Host "An error occurred when logging on $_"
+            break
+        }
+    }
+    function Show-Menu
+    {
+        param (
+        [string]$Title = 'VMware Workspace ONE UEM API Menu'
+        )
+        Clear-Host
+        Write-Host "================ $Title ================"
+        Write-Host "Press '1' to get devices"
+        Write-Host "Press '2' to sync devices"
+        Write-Host "Press 'Q' to quit."
+    }
+    
+    do
+    
+    {
+        Show-Menu
+        $selection = Read-Host "Please make a selection"
+        switch ($selection)
+        {
+            
+            '1' { 
+                Get-Environment 
+                Get-Devices -WSOServer $WSOServer -header $header -Credential $cred
+            } 
+            
+            '2' {
+                Get-Environment
+                Get-EnrolledDevice -Devices $devices
+                Get-DeviceId -EnrolledDevices $enrolledDevices
+                Invoke-DeviceSync -DeviceId $id -WSOServer $WSOServer -header $header -Credential $cred
+            }
+            
+        }
+        pause
+    }
+    until ($selection -eq 'Q')
+    


### PR DESCRIPTION
Two versions; one for use within Task Scheduler, one for use on an ad-hoc basis with manual entry of api key, credentials and API URL