### PR TITLE
Sensor for returning the sha256 hash of the hosts file on a Windows

### DIFF
--- a/UEM-Samples/Sensors/Windows/os_network_hosts_filehash.ps1
+++ b/UEM-Samples/Sensors/Windows/os_network_hosts_filehash.ps1
@@ -1,0 +1,22 @@
+<#
+Returns the sha256 hash of the hosts file on a system.
+
+DATE        EDITOR          DESCRIPTION OF CHANGE
+2022-06-27  Brian Deyo      Initial sensor script
+2022-06-28  Brian Deyo      Removed non-standard hash detection. That will be better setup downstream.
+
+#>
+
+[string]$hostsFileHash
+$hosts = "$($env:windir)\System32\drivers\etc\hosts"
+
+
+
+if (test-Path $hosts) {
+    $hostsFileHash = Get-FileHash -Path $hosts -Algorithm:SHA256
+    $hostsFileHash = $hostsFileHash.hash 
+}
+else {
+    $hostsFileHash = "Hosts file not located via Sensor"
+}
+return $hostsFileHash


### PR DESCRIPTION
Sensor for returning the sha256 hash of the hosts file on a Windows system

Signed-off-by: Brian Deyo <bdeyo@vmware.com>