### PR TITLE
Updated preinstall script with precheck for valid Python3 no clobber

### DIFF
--- a/UEM-Samples/Utilities and Tools/macOS/Migration-Tool/Migration-Tool-Monterey/scripts/preinstall
+++ b/UEM-Samples/Utilities and Tools/macOS/Migration-Tool/Migration-Tool-Monterey/scripts/preinstall
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+rm /var/log/vmw_migrator.log
+echo "-----Starting Migration----" > /var/log/vmw_migrator.log
+
 #notify user that migration is underway - intelligent hub is downloading and installing
 alertText="Mac Migration In Progress..."
 alertMessage="Please standby as the migration is underway. Further diaglog and input will begin shortly..."
@@ -18,108 +21,214 @@ if [ ! -d "/Applications/Workspace ONE Intelligent Hub.app" ]; then
       if [ -f "$hubfile" ]; then
           echo "hub already downloaded" >> /var/log/vmw_migrator.log
       else
+      		echo "Downloading Hub" >> /var/log/vmw_migrator.log
           curl -o "$hubfile" $hubURL
       fi
   fi
 fi
 
 # check if Installed
-if [ -d "/Applications/Workspace ONE Intelligent Hub.app" ]; then
+if [ -d "/Applications/Workspace ONE Intelligent Hub.app" ];
+then
     echo "hub already installed" >> /var/log/vmw_migrator.log
 else
     #install hub
+    echo "Installing Hub" >> /var/log/vmw_migrator.log
     installer -pkg "$dlLocation/hub.pkg" -target /
     #close hub after install
-    hubStatus=$(/bin/ps aux | /usr/bin/grep "/Applications/Workspace ONE Intelligent Hub.app/Contents/MacOS/Intelligent Hub" | /usr/bin/grep -v "grep")
-    while [ ! -n "$hubStatus" ]
-    do
-      #waiting for hub to launch
-      #echo "not launched"
-      hubStatus=$(/bin/ps aux | /usr/bin/grep "/Applications/Workspace ONE Intelligent Hub.app/Contents/MacOS/Intelligent Hub" | /usr/bin/grep -v "grep")
-    done
-    #kill hub
-    /bin/ps auxww | /usr/bin/grep -i "/Applications/Workspace ONE Intelligent Hub.app/Contents/MacOS/Intelligent Hub" | /usr/bin/grep -v "grep" | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill
+		hubStatus=$(/bin/ps aux | /usr/bin/grep "/Applications/Workspace ONE Intelligent Hub.app/Contents/MacOS/Intelligent Hub" | /usr/bin/grep -v "grep")
+		while [ -z "$hubStatus" ]
+		do
+			#waiting for hub to launch
+			#echo "not launched"
+			hubStatus=$(/bin/ps aux | /usr/bin/grep "/Applications/Workspace ONE Intelligent Hub.app/Contents/MacOS/Intelligent Hub" | /usr/bin/grep -v "grep")
+		done
+		#kill hub
+		/bin/ps auxww | /usr/bin/grep -i "/Applications/Workspace ONE Intelligent Hub.app/Contents/MacOS/Intelligent Hub" | /usr/bin/grep -v "grep" | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill
 fi
 
-# Make python3 file in /usr/local/bin
-FILE=/usr/local/bin/python3
-if [ ! -f "$FILE" ]; then
-  echo "Adding link to python3 from hub" >> /var/log/vmw_migrator.log
-  ln -sf /Library/Application\ Support/AirWatch/Data/Munki/bin/Python.framework/Versions/3.10/bin/python3 /usr/local/bin/python3
+
+
+#Check for Python3 and verify that SSL is working
+goodPython=0
+if [ -d "/Library/Frameworks/Python.framework" ];
+	then
+		echo "python installed - checking version" >> /var/log/vmw_migrator.log
+		echo "" >> /var/log/vmw_migrator.log
+		test=$(python3 --version)
+		if [ ! "$test" ];
+			then
+				echo "No Python found!" >> /var/log/vmw_migrator.log
+				echo "" >> /var/log/vmw_migrator.log
+			else
+				echo "$test found.  Checking if ssl is good." >> /var/log/vmw_migrator.log
+				python3 <<- "EOF"
+				#detect current version and make sure it can connect without ssl errors
+				import os
+				import subprocess
+				import sys
+				import urllib.error
+				import urllib.parse
+				import urllib.request
+
+
+				url = "https://as1506.awmdm.com/api/help"
+				req = urllib.request.Request(url=url)
+				try:
+				  response = urllib.request.urlopen(req).read()
+				except Exception as e:
+				  with open('/var/log/vmw_migrator.log', 'a') as f:
+				      f.write('Exception\n')
+				      f.write(str(e))
+				  exit(1)
+				else:
+				  with open('/var/log/vmw_migrator.log', 'a') as f:
+				      f.write('No Exceptions so SSL is good in Python3\n')
+				  exit(0)
+
+				EOF
+
+				if [ ! $? ];
+					then
+						goodPython=1
+				fi
+		fi
+
+	else
+		echo "Python not detected." >> /var/log/vmw_migrator.log
 fi
 
-FILE=~/.zshrc
-if [ ! -f "$FILE" ]; then
-    if grep -Fxq 'export PATH="/usr/local/bin:$PATH"' $FILE
-      then
-        echo "path already updated in .zshrc" >> /var/log/vmw_migrator.log
-    else
-        echo 'export PATH="/usr/local/bin:$PATH"' >> $FILE
-    fi
+if [ $goodPython -eq 0 ];
+	then
+		echo "updating . files" >> /var/log/vmw_migrator.log
+		# Make python3 file in /usr/local/bin
+		FILE=/usr/local/bin/python3
+		if [ ! -f "$FILE" ];
+			then
+				echo "Adding link to python3 from hub" >> /var/log/vmw_migrator.log
+				ln -sf /Library/Application\ Support/AirWatch/Data/Munki/bin/Python.framework/Versions/3.10/bin/python3 /usr/local/bin/python3
+			else
+				echo "Python Link Already exists" >> /var/log/vmw_migrator.log
+		fi
+		export PATH="/usr/local/bin:$PATH"
+		FILE=~/.zshrc
+		if [ ! -f "$FILE" ];
+			then
+				echo "Creating file and updating path in .zshrc" >> /var/log/vmw_migrator.log
+				echo 'export PATH="/usr/local/bin:$PATH"' >> $FILE
+			else
+				if grep -Fxq 'export PATH="/usr/local/bin:$PATH"' $FILE
+					then
+						echo "path already updated in .zshrc" >> /var/log/vmw_migrator.log
+					else
+						echo "updating path in .zshrc" >> /var/log/vmw_migrator.log
+						echo 'export PATH="/usr/local/bin:$PATH"' >> $FILE
+				fi
+		fi
+
+		FILE=~/.bashrc
+		if [ ! -f "$FILE" ];
+			then
+				echo "Creating file and updating path in .zshrc" >> /var/log/vmw_migrator.log
+				echo 'export PATH="/usr/local/bin:$PATH"' >> $FILE
+			else
+				if grep -Fxq 'export PATH="/usr/local/bin:$PATH"' $FILE
+					then
+						echo "path already updated in .zshrc" >> /var/log/vmw_migrator.log
+					else
+						echo "updating path in .bashrc" >> /var/log/vmw_migrator.log
+						echo 'export PATH="/usr/local/bin:$PATH"' >> $FILE
+				fi
+		fi
 fi
 
-FILE=~/.bashrc
-if [ ! -f "$FILE" ]; then
-    if grep -Fxq 'export PATH="/usr/local/bin:$PATH"' $FILE
-      then
-        echo "path already updated in .zshrc" >> /var/log/vmw_migrator.log
-    else
-        echo 'export PATH="/usr/local/bin:$PATH"' >> $FILE
-    fi
+if [ $goodPython -eq 0 ];
+	then
+		echo "Install certifi and update ca certificates" >> /var/log/vmw_migrator.log
+		#Install certifi and update ca certificates
+		echo "$(python3 --version)" >> /var/log/vmw_migrator.log
+
+#		python3 <<- "EOF"
+#		with open('/var/log/vmw_migrator.log', 'a') as f:
+#		  f.write('[preinstall] ' + 'step1 in python' + '\n')
+#		EOF
+
+		python3 <<- "EOF"
+		# install_certifi.py
+		#
+		# sample script to install or update a set of default Root Certificates
+		# for the ssl module.  Uses the certificates provided by the certifi package:
+		#       https://pypi.python.org/pypi/certifi
+		import os
+		import os.path
+		import stat
+		import subprocess
+		import sys
+		import ssl
+
+		STAT_0o775 = ( stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
+		              | stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP
+		              | stat.S_IROTH |                stat.S_IXOTH )
+
+		with open('/var/log/vmw_migrator.log', 'a') as f:
+		  f.write('[preinstall] ' + 'step1 in python' + '\n')
+		  f.close()
+
+		#openssl_dir='/Library/Application Support/AirWatch/Data/Munki/bin/Python.framework/Versions/3.10/etc/openssl'
+		#openssl_cafile='cert.pem'
+
+		migrator_logfile='/var/log/vmw_migrator.log'
+
+		def writeToLog(text):
+		  try:
+		    with open(migrator_logfile, 'a') as f:
+		      f.write('[preinstall] ' + text + '\n')
+		      f.close()
+		  except Exception as e:  # noqa
+		    with open('/var/log/vmw_migrator.log', 'a') as f:
+		      f.write('[preinstall] ' + str(e) + '\n')
+		      f.close()
+		    pass
+
+
+		openssl_dir, openssl_cafile = os.path.split(
+		  ssl.get_default_verify_paths().openssl_cafile)
+
+		writeToLog('writing openssl')
+
+		try:
+		  os.makedirs(openssl_dir)
+		except FileExistsError:
+		  writeToLog('opensssl directory already exists')
+		  pass
+
+		with open(migrator_logfile, 'a') as f:
+		  f.write('[preinstall] ' + '-- pip install --upgrade certifi' + '\n')
+
+		subprocess.check_call([sys.executable,
+		  "-E", "-s", "-m", "pip", "install", "--upgrade", "certifi"])
+		import certifi
+
+		# change working directory to the default SSL directory
+		os.chdir(openssl_dir)
+		relpath_to_certifi_cafile = os.path.relpath(certifi.where())
+		writeToLog('-- removing any existing openssl_cafile')
+		try:
+		  os.remove(openssl_cafile)
+		except FileNotFoundError:
+		  pass
+		writeToLog('-- creating symlink to certifi certificate bundle')
+		os.symlink(relpath_to_certifi_cafile, openssl_cafile)
+		writeToLog('-- setting permissions on cafile')
+		os.chmod(openssl_cafile, STAT_0o775)
+		writeToLog(" -- update complete")
+		EOF
+
+		if [ $? -eq 0 ];
+			then
+				echo "Python was installed successfully" >> /var/log/vmw_migrator.log
+			else
+				echo "something went wrong." >> /var/log/vmw_migrator.log
+		fi
 fi
 
-#Install certifi and update ca certificates
-
-#/Library/Frameworks/Python.framework/Versions/@PYVER@/bin/python@PYVER@ << "EOF"
-/Library/Application\ Support/AirWatch/Data/Munki/bin/Python.framework/Versions/3.10/bin/python3 << "EOF"
-# install_certifi.py
-#
-# sample script to install or update a set of default Root Certificates
-# for the ssl module.  Uses the certificates provided by the certifi package:
-#       https://pypi.python.org/pypi/certifi
-import os
-import os.path
-import ssl
-import stat
-import subprocess
-import sys
-
-STAT_0o775 = ( stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
-             | stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP
-             | stat.S_IROTH |                stat.S_IXOTH )
-def main():
-    #openssl_dir='/Library/Application Support/AirWatch/Data/Munki/bin/Python.framework/Versions/3.10/etc/openssl'
-    #openssl_cafile='cert.pem'
-
-    openssl_dir, openssl_cafile = os.path.split(
-        ssl.get_default_verify_paths().openssl_cafile)
-
-    try:
-        print(1)
-        os.makedirs(openssl_dir)
-    except FileExistsError:
-        print('Error creating directory openssl_cafile')
-        pass
-
-    print(" -- pip install --upgrade certifi")
-    subprocess.check_call([sys.executable,
-        "-E", "-s", "-m", "pip", "install", "--upgrade", "certifi"])
-    import certifi
-
-    # change working directory to the default SSL directory
-    print(2)
-    os.chdir(openssl_dir)
-    relpath_to_certifi_cafile = os.path.relpath(certifi.where())
-    print(" -- removing any existing file or link")
-    try:
-        os.remove(openssl_cafile)
-    except FileNotFoundError:
-        pass
-    print(" -- creating symlink to certifi certificate bundle")
-    os.symlink(relpath_to_certifi_cafile, openssl_cafile)
-    print(" -- setting permissions")
-    os.chmod(openssl_cafile, STAT_0o775)
-    print(" -- update complete")
-if __name__ == '__main__':
-    main()
-EOF


### PR DESCRIPTION
This version of the preinstall script checks for a valid python, then checks ssl connectivity to an environment.  If all good, continue, otherwise install python and make valid.