### PR TITLE
Moved to zsh, eliminated python 2 dependency

### DIFF
--- a/UEM-Samples/Sensors/macOS/Custom Attributes/logged_in_user.sh
+++ b/UEM-Samples/Sensors/macOS/Custom Attributes/logged_in_user.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/zsh
 
-loggedInUser=`python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = SCDynamicStoreCopyConsoleUser(None, None, None)[0]; sys.stdout.write(username + "\n");'`
+loggedInUser=$( scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }' )
 echo $loggedInUser


### PR DESCRIPTION
This removes the dependency on python 2 present in old script. It also moves to standard zsh.
This uses Armin's recommended method https://scriptingosx.com/2020/02/getting-the-current-user-in-macos-update/