### PR TITLE
Update WS1-ReEnroll.ps1

### DIFF
--- a/UEM-Samples/Utilities and Tools/Windows/Migration and Re-Enrollment/Workspace ONE Re-Enrollment/WS1-ReEnroll.ps1
+++ b/UEM-Samples/Utilities and Tools/Windows/Migration and Re-Enrollment/Workspace ONE Re-Enrollment/WS1-ReEnroll.ps1
@@ -839,7 +839,7 @@ elseif ($Arch -eq 'amd64')
 
 #Checking connection to target server before doing anything else
 Write-Log "Verifying connection to the target UEM server: $server"
-$connectionStatus  = Test-Connection -ComputerName $server -Quiet
+$connectionStatus  = Test-Connection -ComputerName $server -TcpPort 80 -Quiet
 if($connectionStatus)
 {
 	Write-Log "Test connection passed."


### PR DESCRIPTION
It appears that VMware blocks ICMP so if we just want to check that the server address is correct and responds then maybe using TCP and port 80 is a better option.