### PR TITLE
reset deferral counter before finalising update

### DIFF
--- a/UEM-Samples/Utilities and Tools/macOS/macOS Updater Utility/macOSupdater.sh
+++ b/UEM-Samples/Utilities and Tools/macOS/macOS Updater Utility/macOSupdater.sh
@@ -1308,6 +1308,8 @@ else # deferal mode
       installUpdate "$updateType"
       #trigger script to notify user that upgrade is installing and reboot is imminent
       log_info "triggering notification script"
+      # reset the deferral counter to 0, so the user will have deferrals available for the next update
+      /usr/bin/defaults write "$counterFile" deferralCount -int 0
       installStatus
   fi
 fi


### PR DESCRIPTION
The current script doesn't reset the deferral counter. This causes the behaviour that, if ever a new `desiredOS` is set in the XML file, the update will be forced immediately, since the deferral counter is already at the limit.

This PR resets the deferral counter to 0 as late as possible before finalising the update, so that any future updates will also allow deferrals.